### PR TITLE
Add Makefile for CentOS6 #1

### DIFF
--- a/Makefile.CentOS6
+++ b/Makefile.CentOS6
@@ -1,0 +1,14 @@
+#Reference: http://www.devdrv.co.jp/linux/kernel26-makefile.htm
+TARGET:= kiken.ko
+
+all: ${TARGET}
+
+kiken.ko: kiken.c
+	make -C /usr/src/kernels/`uname -r` M=`pwd` V=1 modules
+
+clean:
+	make -C /usr/src/kernels/`uname -r` M=`pwd` V=1 clean
+
+obj-m:= kiken.o
+
+clean-files := *.o *.ko *.mod.[co] *~


### PR DESCRIPTION
compatibility for kernel header path in CentOS6
